### PR TITLE
Avoid NameError exception generation

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -674,7 +674,7 @@ module SimpleForm
       return if SimpleForm.inputs_discovery == false && at == Object
 
       begin
-        at.const_get(mapping) if at.constants.include?(mapping.to_sym)
+        at.const_get(mapping) if at.const_defined?(mapping)
       rescue NameError => e
         raise if e.message !~ /#{mapping}$/
       end

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -674,7 +674,7 @@ module SimpleForm
       return if SimpleForm.inputs_discovery == false && at == Object
 
       begin
-        at.const_get(mapping)
+        at.const_get(mapping) if at.constants.include?(mapping.to_sym)
       rescue NameError => e
         raise if e.message !~ /#{mapping}$/
       end


### PR DESCRIPTION
Hardly improves rendering time by avoiding the generation of NameError exception

Rendering a view with 200 inputs allowed me to see that this portion of code is not optimized at all.

I used stackprof on my view to understand via the flamegraph that 80% of the time is dedicated to handle exceptions.

before fix
![before](https://user-images.githubusercontent.com/3259059/106168314-699bca80-618e-11eb-9df6-116b1729e17a.png)

after fix
![after](https://user-images.githubusercontent.com/3259059/106168321-6b658e00-618e-11eb-9e6c-19ee4813e802.png)

This optimisation reduce my rendering time by 5



